### PR TITLE
Option for decompression options in laspy.read()

### DIFF
--- a/ept/ept.py
+++ b/ept/ept.py
@@ -17,7 +17,9 @@ from .laz import LAZ
 
 
 class EPT(object):
-    def __init__(self, url, bounds=None, queryResolution=None):
+    def __init__(
+        self, url, bounds=None, queryResolution=None, decompression_selection=None
+    ):
         query = None
         if ('?' in url):
             [url, query] = url.split('?', 1)
@@ -40,6 +42,7 @@ class EPT(object):
         self.endpoint = Endpoint(self.root_url, self.query)
         self.info = self.get_info()
         self.computedDepth = False
+        self.decompression_selection = decompression_selection
 
     def as_laspy(self, strictbounds=True):
         """
@@ -100,7 +103,10 @@ class EPT(object):
                 url = "/ept-data/" + key.id() + ".laz"
                 await tasks.put(self.endpoint.aget(url, session))
 
-        laz = [LAZ(tasks.data[i]["result"]) for i in tasks.data]
+        laz = [
+            LAZ(tasks.data[i]["result"], self.decompression_selection)
+            for i in tasks.data
+        ]
         return laz
 
     async def overlaps(self):

--- a/ept/laz.py
+++ b/ept/laz.py
@@ -6,5 +6,5 @@ import laspy
 
 
 class LAZ(object):
-    def __init__(self, bytes):
-        self.las = laspy.read(bytes)
+    def __init__(self, bytes, decompression_selection):
+        self.las = laspy.read(bytes, decompression_selection)


### PR DESCRIPTION
Just a simple change for personal use, I added the decompression_selection option to manually decide which fields to decompress. This only works for laz files with version >= 1.4 & point format id >= 6. In the context of entwine, you can force the .laz output files under ept-data to be version 1.4 by adding the --laz_14 flag to the entwine build command. -https://laspy.readthedocs.io/en/latest/api/laspy.compression.html#laspy.compression.DecompressionSelection

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a decompression_selection parameter to the EPT class and LAZ class to allow users to manually select which fields to decompress when reading LAZ files using laspy.

New Features:
- Introduce an option to specify decompression fields in the laspy.read() function for LAZ files with version >= 1.4 and point format id >= 6.

<!-- Generated by sourcery-ai[bot]: end summary -->